### PR TITLE
applications: nrf5340_audio: Add lc3_playback module

### DIFF
--- a/applications/nrf5340_audio/src/audio/audio_datapath.c
+++ b/applications/nrf5340_audio/src/audio/audio_datapath.c
@@ -556,7 +556,6 @@ static void alt_buffer_free_both(void)
  * the in.fifo message queue.
  */
 
-uint8_t sound_mix_buf[BLK_MONO_SIZE_OCTETS];
 static void audio_datapath_i2s_blk_complete(uint32_t frame_start_ts, uint32_t *rx_buf_released,
 					    uint32_t const *tx_buf_released)
 {

--- a/applications/nrf5340_audio/src/audio/audio_system.c
+++ b/applications/nrf5340_audio/src/audio/audio_system.c
@@ -22,7 +22,6 @@
 #include "audio_usb.h"
 #include "streamctrl.h"
 #include "pcm_mix.h"
-#include <hal/nrf_gpio.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(audio_system, CONFIG_AUDIO_SYSTEM_LOG_LEVEL);

--- a/applications/nrf5340_audio/src/modules/lc3_playback.c
+++ b/applications/nrf5340_audio/src/modules/lc3_playback.c
@@ -13,7 +13,7 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lc3_playback, 4); /* For draft PR feedback: going to change this line */
 
-#define RING_BUF_SIZE		960 /* This can be modified */
+#define RING_BUF_SIZE		1920 /* This can be modified */
 #define lc3_playback_STACK_SIZE 4096
 
 /*File structure of the LC3 encoded files*/
@@ -166,7 +166,6 @@ static int lc3_playback_play(const char *filename, const char *path_to_file)
 	}
 	lc3_playback_active = true;
 	for (uint32_t i = 0; i < lc3_frames_num; i++) {
-
 		/* Skip the frame length info to get to the audio data */
 		ret = sd_card_segment_skip(&lc3_fr_len_size);
 		if (ret < 0) {
@@ -209,7 +208,7 @@ static void lc3_playback_thread(void *arg1, void *arg2, void *arg3)
 	while (!sw_codec_is_initialized()) {
 		k_msleep(100);
 	}
-	lc3_playback_play("enc_21.bin", "");
+	lc3_playback_play("enc_3.bin", "");
 }
 
 int lc3_playback_init(void)

--- a/applications/nrf5340_audio/tools/buildprog/nrf5340_audio_dk_devices.json
+++ b/applications/nrf5340_audio/tools/buildprog/nrf5340_audio_dk_devices.json
@@ -1,11 +1,11 @@
 [
  {
-        "nrf5340_audio_dk_snr": 1050183438,
+        "nrf5340_audio_dk_snr": 1000,
         "nrf5340_audio_dk_dev": "headset",
         "channel": "left"
  },
  {
-        "nrf5340_audio_dk_snr": 1050139103,
+        "nrf5340_audio_dk_snr": 1000,
         "nrf5340_audio_dk_dev": "gateway",
         "channel": "NA"
  },


### PR DESCRIPTION
Draft PR for the lc3 playback module. 
Note: There is not currently support for using 2 decoding channels without entering the SW_CODEC_STEREO-case in sw_codec_select. The solution I have implemented here is very hacky and is not meant as a permanent solution, obviously. Also, a large part of the changes shown in the diff is automatic formatting stuff.